### PR TITLE
fix(install): Install docker-compose using curl instead of apt-get

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -148,7 +148,7 @@ fi
 if [[ "$NEED_INSTALL_DOCKER_COMPOSE" == "YES" ]]; then
    echo "----------------------------------------------------"
    echo "Installing Docker-compose  ....."
-   sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+   sudo curl -L "https://github.com/docker/compose/releases/download/${MIN_VERSION_DOCKER_COMPOSE}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
    sudo chmod +x /usr/local/bin/docker-compose
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -148,7 +148,8 @@ fi
 if [[ "$NEED_INSTALL_DOCKER_COMPOSE" == "YES" ]]; then
    echo "----------------------------------------------------"
    echo "Installing Docker-compose  ....."
-   yes | sudo apt install docker-compose
+   sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+   sudo chmod +x /usr/local/bin/docker-compose
 fi
 
 echo "Dounload setup files ----------------------------------"

--- a/install.sh
+++ b/install.sh
@@ -152,7 +152,7 @@ if [[ "$NEED_INSTALL_DOCKER_COMPOSE" == "YES" ]]; then
    sudo chmod +x /usr/local/bin/docker-compose
 fi
 
-echo "Dounload setup files ----------------------------------"
+echo "Download setup files ----------------------------------"
 
 [ -d ./ui-bakery-on-premise ] || mkdir ui-bakery-on-premise
 cd ui-bakery-on-premise


### PR DESCRIPTION
Install docker-compose using curl instead of apt-get, because it is easier to control the version for different versions of host OS.